### PR TITLE
Update package.json: 修复 puppeteer 依赖声明方式

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     }
   },
   "peerDependencies": {
-    "koishi": "^4.16.0",
-    "koishi-plugin-puppeteer": "*"
+    "koishi": "^4.16.0"
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.12",


### PR DESCRIPTION
### 问题描述

当前项目在 `package.json` 的 `peerDependencies` 中直接声明了 `koishi-plugin-puppeteer` 依赖，这不符合 Koishi 插件的最佳实践。

### 解决方案

根据 Koishi 插件开发规范，当插件需要使用其他插件提供的服务时，应该：
1. 在 `koishi.service.required` 中声明所需的服务名称
2. 而不是直接将服务提供插件写入依赖项

### 当前状态

项目已经正确地在 `package.json` 中声明了所需服务：

```json
"koishi": {
  "service": {
    "required": [
      "puppeteer"
    ]
  }
}
```
